### PR TITLE
[MER-2915] fix: branch branch --> base branch

### DIFF
--- a/mergequeue/base-branches.md
+++ b/mergequeue/base-branches.md
@@ -2,7 +2,7 @@
 
 By default, Aviator monitors all PRs in a repository and will enqueue all of them for merging. Internally, Aviator automatically manages separate queues for each base branch. So if you have a PR #1 that is targeting base branch main and PR #2 that is targeting base branch release/v3.4, then those two PRs will not conflict with each other.
 
-You can explicitly specify base branches that Aviator should monitor, this way Aviator will ignore any PRs that target a different base branch. A branch branch can also be specified as a glob pattern. Here’s an example config:
+You can explicitly specify base branches that Aviator should monitor, this way Aviator will ignore any PRs that target a different base branch. A base branch can also be specified as a glob pattern. Here’s an example config:
 
 ```
 merge_rules:


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":""}
```
-->
