### PR TITLE
fix(docs): remove trailing `\`

### DIFF
--- a/mergequeue/concepts/priority-merges/instant-merges.md
+++ b/mergequeue/concepts/priority-merges/instant-merges.md
@@ -67,7 +67,3 @@ Once migrated to Ruleset, you can add Aviator app in the bypass list.
 If you cannot migrate your branch protection rules to Ruleset, you can also use a Personal Access Token associated with a user who has GitHub admin permissions. Remember to give repo: read-write permissions when generating a token. In this case, when using instant merge, Aviator will use this personal access token.
 
 If you need assistance in setting up the personal access token, please contact [<mark style="color:blue;">howto@aviator.co</mark>](mailto:howto@aviator.co).
-
-\
-\
-\\


### PR DESCRIPTION
somebody lost a `\`

<img width="842" height="412" alt="Screenshot 2026-04-13 at 2 45 26 PM" src="https://github.com/user-attachments/assets/bf2d22d7-0c44-4d93-9bbc-f6ba5c9bf23f" />
