### PR TITLE
add validate-config slash command to docs

### DIFF
--- a/mergequeue/configuration-file.md
+++ b/mergequeue/configuration-file.md
@@ -20,6 +20,8 @@ You can directly apply the config on the _YAML configuration_ tab on the [<mark 
 
 You can also create a configuration file stored in `.aviator/config.yml`. The file will only be read once it is merged into the repository's default branch. It will also override any properties set in the Dashboard UI.
 
+To validate your configuration before merging, use the `/aviator validate-config` [slash command](reference/slash-commands.md#validate-config) on your pull request. Aviator will post a comment indicating whether the config is valid or listing any errors.
+
 ### Config Schema
 
 You can see [<mark style="color:blue;">the complete config schema</mark>](https://app.aviator.co/schema/index.html#aviator_config_yaml.json) as well as [<mark style="color:blue;">the JSON schema</mark>](https://app.aviator.co/schema/aviator_config_yaml.json) for autocompletion and validation purpose.

--- a/mergequeue/reference/slash-commands.md
+++ b/mergequeue/reference/slash-commands.md
@@ -68,6 +68,10 @@ The `/aviator backport` command can be used to backport a given PR to the specif
 
 The `/aviator sync` command synchronizes the PR to be up-to-date with its base branch (i.e., creates a merge commit or rebases on top of the latest commit from the base branch, depending on your repository configuration).
 
+## Validate Config
+
+The `/aviator validate-config` command validates the `.aviator/config.yml` file on the current PR branch. Aviator will post a comment on the PR indicating whether the configuration is valid or listing any validation errors. This is useful for catching configuration mistakes before merging into the default branch.
+
 ## Blocking
 
 The `/aviator block until` command will block a PR from being merged until a certain block condition is met. Aviator current supports blocking by PR (example: `\aviator block until #382)` and blocking by timestamp (example: `\aviator block until Monday 9pm`). For more information, view the [how-to guide](https://app.gitbook.com/o/RHS3UXVvKc7g6MUrTeGU/s/OAPqUQVbLbsfI5YESl32/~/changes/367/mergequeue/how-to-guides/how-to-block-pull-request-mergeing-with-slash-commands).


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
