### PR TITLE
docs: update MergeQueue config dashboard URLs and button names

### DIFF
--- a/mergequeue/concepts/audit-trail.md
+++ b/mergequeue/concepts/audit-trail.md
@@ -9,7 +9,7 @@ description: >-
 
 It is important to know when your merge rules have been changed, and who changed them. We store a history of your merge rules configuration so that you can see exactly that.
 
-Audit trail information can be found on the [<mark style="color:blue;">Merge Rules</mark>](https://app.aviator.co/github/rules) page under the `Configuration History` tab.
+Audit trail information can be found on the [<mark style="color:blue;">Merge Rules</mark>](https://app.aviator.co/queue/config) page under the `Configuration History` tab.
 
 ## What Gets Stored?
 
@@ -17,7 +17,7 @@ For each of the ways that you may set up your merge rules, we store different re
 
 ### Dashboard UI
 
-When changes are made from the [<mark style="color:blue;">Merge Rules</mark>](https://app.aviator.co/github/rules) dashboard, we store the logged in `aviator_user` that made them, the time the change was made at, and a `diff` of the new configuration to the previous one.
+When changes are made from the [<mark style="color:blue;">Merge Rules</mark>](https://app.aviator.co/queue/config) dashboard, we store the logged in `aviator_user` that made them, the time the change was made at, and a `diff` of the new configuration to the previous one.
 
 <figure><img src="../../.gitbook/assets/Screen Shot 2022-09-19 at 6.01.12 PM.png" alt=""><figcaption><p>A configuration history record of a change made via Dashboard UI</p></figcaption></figure>
 
@@ -25,7 +25,7 @@ As can be seen above, the `aviator_user` is displayed as the email associated wi
 
 ### Dashboard YAML
 
-Similarly to the above, when changes are made to [<mark style="color:blue;">Merge Rules</mark>](https://app.aviator.co/github/rules) YAML under the `Yaml Configuration` tab, we store the `aviator_user` that logged in to make the change, the time, and the `diff` of the current and previous YAML.
+Similarly to the above, when changes are made to [<mark style="color:blue;">Merge Rules</mark>](https://app.aviator.co/queue/config) YAML under the `Yaml Configuration` tab, we store the `aviator_user` that logged in to make the change, the time, and the `diff` of the current and previous YAML.
 
 Since changes here are made directly to the YAML shown on the `Yaml Configuration` tab, it should be more obvious how the text difference is generated in this case.
 

--- a/mergequeue/configuration-file.md
+++ b/mergequeue/configuration-file.md
@@ -8,11 +8,11 @@ description: >-
 
 MergeQueue communicates with pull request using GitHub labels, GitHub comments and the [<mark style="color:blue;">Aviator CLI</mark>](../aviator-cli/). Merge rules are at the core of how the Aviator bot reacts to the actions taken on GitHub.
 
-Some of the Basic Configuration can be modified using the [<mark style="color:blue;">Merge Rules dashboard</mark>](https://app.aviator.co/github/rules). For more advanced configuration, Aviator supports a YAML based configuration file. This file can either be applied directly from the Aviator dashboard or configured in the GitHub repository.
+Some of the Basic Configuration can be modified using the [<mark style="color:blue;">Merge Rules dashboard</mark>](https://app.aviator.co/queue/config). For more advanced configuration, Aviator supports a YAML based configuration file. This file can either be applied directly from the Aviator dashboard or configured in the GitHub repository.
 
 ### Managing YAML from the dashboard
 
-You can directly apply the config on the _YAML configuration_ tab on the [<mark style="color:blue;">Merge Rules</mark>](https://app.aviator.co/github/validate-config) page. We also recommend validating this configuration before applying any changes.
+You can edit the YAML config directly on the [<mark style="color:blue;">Merge Rules</mark>](https://app.aviator.co/queue/config) page. Use the **Validate** button to check the config, then click **Save & Apply** to apply your changes. We recommend validating the configuration before saving.
 
 <figure><img src="../.gitbook/assets/Screen Shot 2023-10-12 at 3.22.07 PM.png" alt=""><figcaption></figcaption></figure>
 


### PR DESCRIPTION
## Summary
- The Merge Rules config page has moved from `app.aviator.co/github/rules` and `app.aviator.co/github/validate-config` to `app.aviator.co/queue/config`. Update the five remaining links in the MergeQueue docs.
- Clarify the YAML editor flow: use the **Validate** button to check the config, then click **Save & Apply** to apply changes.

## Files changed
- `mergequeue/configuration-file.md` — 2 URL updates + button naming on the "Managing YAML from the dashboard" section
- `mergequeue/concepts/audit-trail.md` — 3 URL updates

## Test plan
- [ ] Render the changed pages in the GitBook preview
- [ ] Confirm both updated links resolve to the new YAML config editor
- [ ] Confirm the button names match what is shown on the editor today