### PR TITLE
Document registering preview images from a container registry

### DIFF
--- a/verify/how-to-guides/creating-a-preview.md
+++ b/verify/how-to-guides/creating-a-preview.md
@@ -1,6 +1,6 @@
 # Creating a preview
 
-This guide walks through adding a preview to a repo end-to-end: registering an image with Aviator, declaring runtime secrets, configuring the preview block in `aviator/verify.yaml`, and confirming it boots.
+This guide walks through adding a preview to a repo end-to-end: registering an image with Aviator, declaring runtime secrets, configuring the preview in your Aviator Verify settings, and confirming it boots.
 
 By the end, you'll have a working `default` preview that scenarios can run against.
 
@@ -17,10 +17,39 @@ For the concept overview, see [Concepts: Previews](../concepts/previews.md). For
 
 ### Step 1: Register a preview image
 
-Aviator caches preview images locally and boots a container from the cached copy per run.
+Aviator boots a preview container from an image you register under **Settings → Sandboxes**. Give it a short, stable name — e.g. `api-preview` — which you'll reference from your preview config. There are two ways to register one.
 
-1. Open **Settings → Sandboxes** in the Aviator UI.
-2. Register the image you want previews to boot from. Give it a short, stable name — e.g. `api-preview`. You'll reference this name from `verify.yaml`.
+#### Option A: From a Dockerfile
+
+Provide a Dockerfile and Aviator builds the image for you. Choose this when your service's environment can be assembled from packages and you want Aviator to own the build.
+
+Bake in everything your service needs to run — the language runtime, system packages, and dependencies (`apt` / `npm` / `pip` installs). `git`, `git-lfs`, and the coding-agent CLI are added automatically. `COPY` and `ADD` **aren't supported**, so you can't bake your own source into the image this way — Aviator checks out the branch under test at boot, and your setup script (Step 4) builds and starts the service from that checkout.
+
+#### Option B: From a container registry image
+
+Point Aviator at an image you already publish to your own registry — AWS ECR, Google Artifact/Container Registry, or any generic registry (Docker Hub, GHCR, Artifactory, self-hosted).
+
+Choose this when you want the preview to run your *real* environment rather than one reconstructed from a Dockerfile:
+
+* **Bake in anything, not just packages.** Since an Aviator-built Dockerfile can't `COPY`/`ADD`, it can only install public packages. A registry image can contain whatever your build produces — compiled binaries, private artifacts, a fully prepared environment.
+* **Reuse the image your CI already builds.** One build definition instead of a second Dockerfile to keep in sync, so previews mirror what you actually ship — and it covers private base images and build-time secrets Aviator's builder can't use.
+* **Faster, prod-like boots.** Bake the repository into the image (see **Repo root** below) and Aviator fetches the branch in place instead of cloning it fresh each run.
+
+1. Open **Settings → Sandboxes → Add → From Registry Image**.
+2. Select the registry type and enter the fully-qualified image reference, e.g. `123456789.dkr.ecr.us-west-2.amazonaws.com/api:latest`.
+3. Provide **read-only** pull credentials. Scope them as tightly as possible — Aviator only needs to pull and inspect the image:
+   * **AWS ECR** — an access key ID, secret access key, and region for an IAM principal with `AmazonEC2ContainerRegistryReadOnly` on the repository.
+   * **GCP** — a service-account key (JSON) with `roles/artifactregistry.reader` on the repository.
+   * **Generic** — a username and password/token (omit both for a public image).
+
+   Credentials are stored encrypted and are never displayed again.
+4. *(Optional)* If your image already has the repository checked out — for example, baked in during your own CI build — set **Repo root** to that path (e.g. `/code`). The preview runs from there instead of cloning the branch fresh. Leave it blank to have Aviator clone the branch at boot.
+
+The image **must include `git`** — Aviator checks out (or updates) the branch under test inside the container at boot.
+
+After you register the image, Aviator pulls and prepares it. The image card shows **Building**, then **Success** once it's ready — reference it from your preview config at that point.
+
+**Keeping a registry image current.** When you push a new image to the same tag, Aviator re-pulls and rebuilds it automatically within the hour — and only when the tag's digest has actually changed, so an unchanged tag costs nothing. To pull a new build immediately, open the image under **Settings → Sandboxes** and click **Check for Update**. To pin an exact build that never moves, reference an image digest (`…@sha256:…`) instead of a tag.
 
 If you don't have a service image yet, the simplest path is to start with a base image that has your runtime (e.g. `node:20`) and let the setup script install dependencies. As your previews mature, bake more into the image.
 
@@ -36,44 +65,49 @@ For each runtime secret:
 
 Naming matters: each secret is injected into the preview as an environment variable of the same name.
 
-### Step 3: Declare the preview in verify.yaml
+### Step 3: Configure the preview
 
-Add a `preview` block to `aviator/verify.yaml`:
+Previews are configured in your **Aviator Verify settings**. Add a `preview` entry under `verify`:
 
 ```yaml
-preview:
-  - name: default
-    image: api-preview
-    port: 8000
-    setup: .aviator/scripts/preview-setup.sh
-    secrets:
-      - DB_PASSWORD
-      - STRIPE_KEY
+verify:
+  preview:
+    - name: default
+      image: api-preview
+      port: 8000
+      setup: .aviator/scripts/preview-setup.sh
+      secrets:
+        - DB_PASSWORD
+        - STRIPE_KEY
 ```
 
-Three things to get right:
+The fields to get right:
 
-* **`image`** — the name you registered in Step 1.
+* **`image`** — the image name you registered in Step 1.
 * **`port`** — the port your service listens on inside the container. This is what the scenario runner connects to.
-* **`secrets`** — every name listed here must exist in the secret store and be granted to this repo, or the boot will fail with a clear error.
+* **`setup`** — path in your repo to the script that starts your service (see Step 4).
+* **`secrets`** — every name listed here must exist in your secret store and be granted to this repo, or the boot fails with a clear error.
 
-If you don't need a setup script (the image is fully self-contained), omit the `setup` line.
+### Step 4: Write the setup script
 
-### Step 4: Write the setup script (optional)
+The setup script is what **starts your service** — it's the launch point of every preview, so this step isn't optional. Aviator runs it once inside the container at boot, after checking out the branch under test, and it's also where migrations, fixtures, and warm-up belong. Your declared secrets and a `PREVIEW_URL` variable are injected into the script's environment.
 
-`setup` runs inside the container after start and before the port is marked ready. It's the right place for migrations, light fixtures, and warm-up.
-
-Create `.aviator/scripts/preview-setup.sh` in the repo:
+Create `.aviator/scripts/preview-setup.sh` in the repo (at the path your `setup` field points to):
 
 ```bash
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Run migrations on the test database.
+# Build/install from the checked-out source, run migrations, seed fixtures.
 ./bin/api migrate
-
-# Seed a small fixture so scenarios have something to query.
 ./bin/api seed --fixture=tests/fixtures/preview.json
+
+# Start the service in the BACKGROUND so this script can exit — Aviator marks
+# the preview ready once the script returns. Listen on your configured port.
+nohup ./bin/api serve --port 8000 > /tmp/preview.log 2>&1 &
+
+# There's no health check, so give the port a moment to come up before exiting.
+sleep 2
 ```
 
 Make it executable:
@@ -84,18 +118,18 @@ chmod +x .aviator/scripts/preview-setup.sh
 
 Two rules of thumb:
 
-* **Make it idempotent.** It runs every time the preview boots.
-* **Keep it fast.** Heavy work belongs in the image, not in setup. See [Managing previews](managing-previews.md) for the bake-vs-setup tradeoff.
+* **Start the service in the background and let the script return.** Aviator marks the preview ready when the script exits `0` — there's no separate health check — so background your server and confirm the port is listening before the script finishes. If the script runs the server in the foreground, it never returns and the boot times out.
+* **Keep it fast.** Heavy, rarely-changing work (dependency installs, compilation) belongs in the image, not here — setup time is part of every run's latency. See [Managing previews](managing-previews.md) for the bake-vs-setup tradeoff.
 
 ### Step 5: Commit and trigger a verification
 
-Commit the `verify.yaml` change and the setup script. Submit through the MCP (or open a PR if you've already submitted).
+Save your preview config in Verify settings and commit the setup script to the repo. Submit through the MCP (or open a PR if you've already submitted).
 
 When the next verification run starts, watch the run timeline in the review document:
 
 * You'll see a "Building preview" line while the container is prepared.
 * Then "Booting preview" while the setup script runs.
-* Then "Preview ready" once the port accepts connections.
+* Then "Preview ready" once the setup script finishes.
 * Scenarios start executing.
 
 If the preview fails to boot, the failure shows up here with the exit code and the last lines of container output.
@@ -110,10 +144,11 @@ If the link works, the preview is fully wired. Reviewers can now open it for ad-
 
 | Symptom                                         | Likely cause                                                                          |
 | ----------------------------------------------- | ------------------------------------------------------------------------------------- |
-| `image not found`                               | The image name in `verify.yaml` doesn't match what's registered in **Sandboxes**, or the image isn't granted to this repo. |
+| `image not found`                               | The image name in your preview config doesn't match what's registered in **Sandboxes**, or the image isn't granted to this repo. |
+| Registry pull / auth error                      | For a registry-sourced image, the stored pull credentials are wrong, expired, or lack read access to the repository. Re-enter them in **Sandboxes**. |
 | Missing secret error                            | A name in `secrets` isn't defined or isn't granted to this repo.                       |
-| Container exits 0 immediately                   | The container's CMD ran a one-off command and exited. Add a long-running process.     |
-| Port never opens                                | Your service binds to `localhost` only. Bind to `0.0.0.0` inside the container.       |
+| Setup script never finishes / times out         | The script runs the server in the foreground and blocks. Start it in the background so the script can exit. |
+| Scenarios can't reach the service               | It bound to `localhost` only, or exited before listening. Bind to `0.0.0.0` on the configured port and confirm it's up before the setup script returns. |
 | Setup script exits non-zero                     | Migration failure or fixture path wrong. The container output shows the exact line.   |
 
 ### Next steps

--- a/verify/how-to-guides/managing-previews.md
+++ b/verify/how-to-guides/managing-previews.md
@@ -13,7 +13,6 @@ Every preview has work that has to happen before scenarios run: dependencies, mi
 | It's slow (`npm install`, downloading large blobs, compiling assets)            | It depends on per-run state (current DB schema, fresh fixtures)              |
 | It rarely changes (system packages, language runtime, compiled binaries)       | It changes every run (re-seeding, applying migrations from `HEAD`)            |
 | It doesn't depend on secrets that are only available at runtime                | It needs runtime secrets to complete                                         |
-| You control the image build and can rebuild on CI                              | The image is a vendor artifact you can't modify                              |
 
 Default: bake heavy work into the image. Use `setup` for the things that genuinely have to be fresh.
 
@@ -21,12 +20,15 @@ A preview that takes 90 seconds to boot is a preview people stop trusting. If yo
 
 ### Keeping the image fresh
 
-`image` references a preview image registered with Aviator. Aviator caches the image locally and boots from the cached copy per run. The freshness of the preview depends on when you push a new version of the image to Aviator.
+`image` references a preview image registered with Aviator. Aviator caches the built image and boots from the cached copy per run, so a preview is only as fresh as the last build it picked up. How it refreshes depends on how the image is registered:
 
-Two patterns work well:
+* **Registry-sourced images.** Push a new image to the same tag. Aviator re-pulls and rebuilds it automatically within the hour — and only when the tag's digest actually changed. To pull a new build immediately, open the image under **Settings → Sandboxes** and click **Check for Update**.
+* **Dockerfile-built images.** Aviator builds these from the Dockerfile you provided at registration. When the contents need to change, register the updated image under **Settings → Sandboxes**.
 
-* **Re-register on every merge.** Wire your CI to push a new version of the image to Aviator under the same name (e.g. `api-preview`) after every merge to `main`. Verify uses the latest version. Simple, recommended for most teams.
-* **Register a versioned name per release.** For changes that need to be reproducible months later for compliance, push `api-preview-v1.42.0` on release and reference that name from `verify.yaml` on the long-lived branch. The exact image used at verification time stays available.
+Two patterns work well for either source:
+
+* **Track a moving tag.** Reference a stable name/tag (e.g. `api-preview`) and let each new push flow through. Simple, recommended for most teams.
+* **Pin an exact build per release.** For changes that must be reproducible months later for compliance, reference an image digest (`…@sha256:…`) or a versioned tag (e.g. `api-preview-v1.42.0`) from `verify.yaml` on the long-lived branch. The exact image used at verification time stays fixed.
 
 ### Multi-preview repos
 
@@ -44,22 +46,9 @@ Previews are torn down after their run completes. The "Open preview" link in the
 
 If a reviewer needs longer access — for a security review, a customer demo, a deep debugging session — extend the preview from the review document UI. Extensions are bounded (typically a few hours), audited, and cost the team explicit acknowledgment.
 
-If you find people extending the same preview repeatedly, that's a signal — either the preview is hard to reproduce locally (consider seeding more state) or the review pattern is wrong (longer-lived staging environments live outside Verify).
-
-### When the preview is wrong
-
-Sometimes the preview itself is the problem, not the code being verified. Signs:
-
-* **Scenarios fail randomly across runs** — usually preview state isn't deterministic. See [Seed data for previews](seed-data-for-previews.md).
-* **Scenarios fail consistently in an unrelated area** — usually a missing secret or migration that should run in `setup`.
-* **The first scenario passes, the rest fail** — usually the preview lacks a reset hook and the first run mutated state the others depend on.
-* **The reviewer's open-preview link 404s or hangs** — usually the container has crashed in the background. Check the run's container output for the exit reason.
-
-When a preview misbehaves, fix the preview before you debug the code. A flaky preview produces flaky verdicts and erodes trust in verification fast.
-
 ### Updating an existing preview
 
-Most preview changes are safe to ship as a normal commit — verify.yaml is read fresh every run.
+Most preview changes are low-risk — your setup script is read fresh from the branch every run, and config changes take effect as soon as you save them in Verify settings.
 
 Two exceptions:
 


### PR DESCRIPTION
Expands the **Creating a preview** how-to (Step 1) to document the new ability to register a preview image from a container registry, alongside the existing Dockerfile path.

Covers:
- AWS ECR / GCP Artifact Registry / generic registries
- read-only credential scoping per registry type
- the `git` base-image requirement
- same-tag auto-refresh and digest pinning
- a registry pull/auth row in the boot-failures table

Pairs with the registry-sourced custom e2b templates work in mergeit (PRs #12873 / #12874).

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
