### PR TITLE
[MER-6942] verify: document auto-run triggers

### DIFF
--- a/verify/concepts/audit-trails-and-compliance.md
+++ b/verify/concepts/audit-trails-and-compliance.md
@@ -10,7 +10,7 @@ For every runbook:
 | --------------------- | ------------------------------------------------------------------------------------------------------ |
 | Runbook submission    | Submitter, timestamp, intent, acceptance criteria, target branch, working branch, repo + commit         |
 | Runbook version       | Each iteration of the runbook (steps + acceptance criteria), with version number                       |
-| Verification run      | Trigger source (manual / commit-push / step-complete / criteria-edit), commit SHA, run status, counts (passed / failed / skipped / waived) |
+| Verification run      | Trigger source (manual / ready / approval / queued / linked / criteria-edit), commit SHA, run status, counts (passed / failed / skipped / waived) |
 | Verification result   | One per criterion: verifier path, verdict, evidence reference, reason, location                        |
 | Reviewer waiver       | Reviewer, timestamp, criterion, category (false-positive / doesn't-apply / accepted-risk / fix-in-followup), free-text reason |
 

--- a/verify/concepts/how-verification-works.md
+++ b/verify/concepts/how-verification-works.md
@@ -4,13 +4,35 @@ This document goes deeper than the [How it works](../how-it-works.md) narrative.
 
 ### A verification run, end to end
 
-A run starts when the agent submits a runbook through the MCP and acceptance criteria are generated (or read from the supplied spec). Aviator does three things in order:
+Once a verification auto-run trigger fires (or you start a run by hand), Aviator does three things in order:
 
 1. **Constructs the run.** Pulls the change set (the diff against the target branch), the acceptance criteria, and the invariants whose conditions match the change. Allocates a preview if any criterion will need one.
 2. **Routes each check through the pipeline.** Every criterion runs through one of two verifier paths. Verdicts are produced in parallel where possible.
 3. **Compiles the results.** Verdicts, evidence, and links to the preview are assembled into the review document.
 
 The run is observable in real time — the review document streams updates as verdicts land.
+
+### When a run is triggered
+
+Verify runs against an open PR. Aside from manual runs you start yourself, it runs on its own at a few specific moments in the PR's life rather than on every push:
+
+| Moment             | Runs when                                                              | Run label      |
+| ------------------ | --------------------------------------------------------------------- | -------------- |
+| **PR ready**       | A PR with acceptance criteria first becomes ready for review (leaves draft). | `on PR ready`  |
+| **Approval**       | The PR receives code-owner approval.                                  | `on approval`  |
+| **Queued**         | The PR is added to the merge queue.                                   | `on queue`     |
+| **PR linked**      | An externally-opened PR is linked to a runbook.                       | `on PR link`   |
+| **Criteria edited**| Acceptance criteria are edited through the `editRunbook` MCP tool.    | replaces the in-flight run |
+
+A plain push to the branch does **not** start a run. Pushing keeps the change set fresh and pre-computes baselines so the next triggered run is fast, but the verdict you already have stands until one of the moments above fires. You can also start a run by hand from the runbook UI — manual runs bypass every rule below and always execute.
+
+Verify de-duplicates so the same change isn't verified twice:
+
+* **PR ready** fires once per PR. Flipping it back to draft and ready again, or amending the commit, won't re-run it.
+* **Approval**, **queued**, and **PR linked** each run once per commit + criteria set. Duplicate webhooks, repeated approvals, or re-queues on the same commit are no-ops.
+* **Criteria edited** supersedes an in-flight run that was using the old criteria — the stale run is cancelled and a fresh one starts on the new criteria.
+
+A failed run doesn't count against de-duplication, so re-triggering after a pipeline issue works. And if baseline invariants for a commit haven't been selected yet, the run is **deferred** and starts automatically once that selection finishes — see [Understanding verification results](../reference/understanding-verification-results.md) for the `deferred` status.
 
 ### The criterion pipeline
 

--- a/verify/how-to-guides/export-audit-logs.md
+++ b/verify/how-to-guides/export-audit-logs.md
@@ -63,7 +63,7 @@ Each record carries fields specific to its type. Common shapes:
 | `run_id`        | Unique ID.                                                                        |
 | `runbook_number`| The runbook this run belongs to.                                                  |
 | `runbook_version`| The version of the runbook that was verified.                                    |
-| `trigger_source`| `manual`, `commit_push`, `step_complete`, or `criteria_edit`.                     |
+| `trigger_source`| `manual`, `ready`, `approval`, `queued`, `linked`, or `criteria_edit`.            |
 | `commit_sha`    | The commit verified.                                                              |
 | `status`        | `pending`, `in_progress`, `passed`, `failed`, `error`, `deferred`.                |
 | `criteria_total / passed / failed / skipped / waived` | Aggregate counts.                            |

--- a/verify/reference/mcp-tools.md
+++ b/verify/reference/mcp-tools.md
@@ -20,7 +20,7 @@ Restart the agent after configuring. The Aviator tools should appear in the agen
 
 ### `specSubmit`
 
-Submits a runbook to Aviator. It captures two things: the **intent** for the change (what it's for, in plain language), and the **acceptance criteria** the change must satisfy. From this point on, verification runs against this runbook.
+Submits a runbook to Aviator. It captures two things: the **intent** for the change (what it's for, in plain language), and the **acceptance criteria** the change must satisfy.
 
 **When to call it:** when the user explicitly asks to submit to Aviator. Never call it proactively.
 

--- a/verify/reference/understanding-verification-results.md
+++ b/verify/reference/understanding-verification-results.md
@@ -30,7 +30,7 @@ A run's record carries trigger context plus aggregate counts:
 | Field            | Description                                                                            |
 | ---------------- | -------------------------------------------------------------------------------------- |
 | `status`         | One of the values above.                                                               |
-| `trigger_source` | What kicked the run off: `manual`, `commit_push`, `step_complete`, `criteria_edit`.    |
+| `trigger_source` | What kicked the run off: `manual`, `ready`, `approval`, `queued`, `linked`, `criteria_edit`. |
 | `runbook_version`| Version of the runbook that was verified (matches what `getRunbook` returned at submission time). |
 | `commit_sha`     | The commit verified.                                                                   |
 | `criteria_total` | Total criteria evaluated in this run.                                                   |

--- a/verify/your-first-spec.md
+++ b/verify/your-first-spec.md
@@ -88,7 +88,7 @@ For the health endpoint without a preview, you should see something like:
 
 With a preview configured, the behavioral criteria would route to Runtime instead — and you'd see the actual request + response as evidence.
 
-Click any verdict to see the evidence. If something failed, the verdict is annotated with the file and line that caused it. Push a fix and Verify will re-run automatically — no new submission needed.
+Click any verdict to see the evidence. If something failed, the verdict is annotated with the file and line that caused it. Fix the issue, then start another run from the runbook UI — a plain push doesn't re-run Verify on its own (see [When a run is triggered](concepts/how-verification-works.md#when-a-run-is-triggered)).
 
 ### Step 7: Approve (or send back)
 


### PR DESCRIPTION
Documents when Verify auto-runs, aligning the docs with the four intentional trigger moments (plus criteria-edit) shipped in mergeit #12922. Before this, the docs described the old per-push model and never explained when a run starts across a PR's life.

## Changes
- **`concepts/how-verification-works.md`**: new "When a run is triggered" section covering the auto-run moments (PR ready / approval / queued / PR linked / criteria edited), what doesn't trigger a run (plain pushes), manual runs, de-duplication, and deferred-until-baselines behavior. Corrected the run-start sentence so it no longer claims submission starts a run.
- **`audit-trails-and-compliance.md`, `how-to-guides/export-audit-logs.md`, `reference/understanding-verification-results.md`**: updated `trigger_source` value lists to `manual / ready / approval / queued / linked / criteria_edit`.
- **`reference/mcp-tools.md`, `your-first-spec.md`**: corrected claims that submitting or pushing auto-starts a run.
- **`how-it-works.md`**: step 3 now links to the new section.